### PR TITLE
Set reasonable dependencies for angular-* packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,9 +19,9 @@
     "README.md"
   ],
   "dependencies": {
-    "angular": ">= 1.0.0",
+    "angular": ">= 1.2.0",
     "angular-ui-router": "*",
-    "angular-sanitize": "latest"
+    "angular-sanitize": ">= 1.2.0"
   },
   "devDependencies": {
     "angular-mocks": ">= 1.0.0"


### PR DESCRIPTION
I think setting `angular-sanitize` to `latest` causes issues during `bower install` - it will bring in the latest `angular-sanitize` which requires the latest `angular`.
